### PR TITLE
docs: fixed typo in get video api path

### DIFF
--- a/website/docs/api/apps/video-library.md
+++ b/website/docs/api/apps/video-library.md
@@ -33,9 +33,9 @@ The following Routes are relating to Videos. These are Publicly accessible route
 
 - **Functionality**: This API call gets all videos from the db.
 
-### 2. GET `/api/videos/:videoId`
+### 2. GET `/api/video/:videoId`
 
-- **Request URL**: `/api/videos/:videoId`
+- **Request URL**: `/api/video/:videoId`
 - **HTTP Method**: GET
 - **Response Body**:
 


### PR DESCRIPTION
In the documentation of the video library, There was a typo in the API path for getting the single video details.

Documentation says: `api/videos/:{videoId}`
Actual Routes defined in server.js: `api/video/:{videoId}`

**Changes Made:**
- Changed the API route path to the actual path defined in the server.js