### PR TITLE
refactor : notes-app archives request body

### DIFF
--- a/website/docs/api/apps/notes-app.md
+++ b/website/docs/api/apps/notes-app.md
@@ -117,12 +117,17 @@ The following Routes are relating to Notes. These are Privately accessible route
 
 - **Functionality**: This API call gets all archived notes of the user from the db.
 
-### 2. POST `/notes/archives/:noteId`
+### 2. POST `/api/notes/archives/:noteId`
 
-- **Request URL**: `/api/archives/:noteId`
+- **Request URL**: `/api/notes/archives/:noteId`
 - **HTTP Method**: POST
 - **Request Headers**: `authorization: encodedToken`
-- **Request Body**: {}
+- **Request Body**:
+  ```js
+  {
+    note;
+  }
+  ```
 - **Response Body**:
 
   ```js


### PR DESCRIPTION
In the documentation of the Notes App, There was a typo mistake in the archive post Request Body and Request URL

**- Request Body:-**
Documentation says: `Request Body: {}`
Actual is: `Request Body: {
  note;
}`

**- Request URL:-**
- Documentation says: `Request URL: /api/archives/:noteId`
Actual is:- `Request URL: /api/notes/archives/:noteId`

**Changes Made:**
   - Changes the Notes App Archive post method Request body as well Request URL
