### PR TITLE
response of delete video in video library

### DIFF
--- a/website/docs/api/apps/video-library.md
+++ b/website/docs/api/apps/video-library.md
@@ -335,7 +335,7 @@ The following Routes are relating to User's Playlists and Playlisted Videos. The
   ```js
   {
     data: {
-      playlists: Array;
+      playlist: Array;
     }
   }
   ```


### PR DESCRIPTION
In the response of delete request of particular video in a particular playlist we get the single playlist instead of the playlists array.
Thanks
Mohit Kumar (pod b, team b2)NEOG 2022