### PR TITLE
docs: fix auth api responses in documentation

### DIFF
--- a/website/docs/api/general/auth.md
+++ b/website/docs/api/general/auth.md
@@ -40,7 +40,7 @@ The Authentication with **mockBee** takes `email` and `password` as credentials 
   ```js
   {
     data: {
-      user, encodedToken;
+      createdUser, encodedToken;
     }
   }
   ```
@@ -64,7 +64,7 @@ The Authentication with **mockBee** takes `email` and `password` as credentials 
   ```js
   {
     data: {
-      user, encodedToken;
+      foundUser, encodedToken;
     }
   }
   ```


### PR DESCRIPTION
Updated docs as per API response.
The API returns the `createdUser` and `foundUser` in the response for `signup` and `login` instead of just `user` in the response.